### PR TITLE
Allow sampledbapi import without mixing namespaces

### DIFF
--- a/sampledbapi/__init__.py
+++ b/sampledbapi/__init__.py
@@ -1,84 +1,14 @@
-import json
-from typing import Any, Dict
+from . import actions, actiontypes, instruments, locations, locationtypes, objects, users, utils
+from .comm import authenticate
 
-import requests
-
-__all__ = ["authenticate", "actions", "actiontypes", "instruments",
-           "locations", "locationtypes", "objects", "users", "utils"]
-
-_address = None
-_api_key = None
-
-
-class SampleDBObject:
-
-    def __init__(self, d: Dict):
-        """Initialize class attributes from dictionary."""
-        for key in dir(self):
-            if not key.startswith("__") and key in d:
-                setattr(self, key, d[key])
-
-
-def authenticate(address: str, api_key: str):
-    """Authenticate with a SampleDB instance
-
-    To retrieve data from SampleDB and upload data to it, you have to
-    authenticate first.
-
-    Arguments:
-        address: URL of the SampleDB server.
-        api_key: API token you can generate using "Preferences/API Tokens".
-    """
-
-    global _address, _api_key
-    old_address, old_key = _address, _api_key
-    _address, _api_key = address, api_key
-    try:
-        get_data("users/me")
-    except requests.exceptions.HTTPError as e:
-        _address, _api_key = old_address, old_key
-        raise Exception("Authentication not successful: " + str(e))
-
-
-def __headers() -> Dict:
-    if _api_key is not None:
-        return {"Authorization": "Bearer " + _api_key}
-    else:
-        raise Exception("You need to provide an API key.")
-
-
-def get_data(path: str) -> Any:
-    if _address is not None:
-        address = _address + "/api/v1/" + path
-        r = requests.get(address, headers=__headers())
-        if r.status_code == 200 or r.status_code == 201:
-            try:
-                return json.loads(r.text)
-            except Exception as e:
-                # We need better error handling here
-                raise Exception("JSON could not be parsed: " + str(e) +
-                                "\nJSON was\n" + r.text)
-        else:
-            r.raise_for_status()
-    else:
-        raise Exception("You have to authenticate first.")
-
-
-def post_data(path: str, data):
-    if _address is not None:
-        address = _address + "/api/v1/" + path
-        data = json.dumps(data)
-        requests.post(address, headers=__headers(),
-                      data=data).raise_for_status()
-    else:
-        raise Exception("You have to authenticate first.")
-
-
-def put_data(path: str, data):
-    if _address is not None:
-        address = _address + "/api/v1/" + path
-        data = json.dumps(data)
-        requests.put(address, headers=__headers(),
-                     data=data).raise_for_status()
-    else:
-        raise Exception("You have to authenticate first.")
+__all__ = [
+    "authenticate",
+    "actions",
+    "actiontypes",
+    "instruments",
+    "locations",
+    "locationtypes",
+    "objects",
+    "users",
+    "utils"
+]

--- a/sampledbapi/actions.py
+++ b/sampledbapi/actions.py
@@ -4,7 +4,7 @@ This is the module docstring.
 
 from typing import List, Optional
 
-from sampledbapi import SampleDBObject, get_data
+from .comm import SampleDBObject, get_data
 
 __all__ = ["Action", "get_list", "get"]
 

--- a/sampledbapi/actiontypes.py
+++ b/sampledbapi/actiontypes.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from sampledbapi import SampleDBObject, get_data
+from .comm import SampleDBObject, get_data
 
 __all__ = ["ActionType", "get_list", "get"]
 

--- a/sampledbapi/comm.py
+++ b/sampledbapi/comm.py
@@ -1,0 +1,81 @@
+import json
+from typing import Any, Dict
+
+import requests
+
+_address = None
+_api_key = None
+
+
+class SampleDBObject:
+
+    def __init__(self, d: Dict):
+        """Initialize class attributes from dictionary."""
+        for key in dir(self):
+            if not key.startswith("__") and key in d:
+                setattr(self, key, d[key])
+
+
+def authenticate(address: str, api_key: str):
+    """Authenticate with a SampleDB instance
+
+    To retrieve data from SampleDB and upload data to it, you have to
+    authenticate first.
+
+    Arguments:
+        address: URL of the SampleDB server.
+        api_key: API token you can generate using "Preferences/API Tokens".
+    """
+
+    global _address, _api_key
+    old_address, old_key = _address, _api_key
+    _address, _api_key = address, api_key
+    try:
+        get_data("users/me")
+    except requests.exceptions.HTTPError as e:
+        _address, _api_key = old_address, old_key
+        raise Exception("Authentication not successful: " + str(e))
+
+
+def __headers() -> Dict:
+    if _api_key is not None:
+        return {"Authorization": "Bearer " + _api_key}
+    else:
+        raise Exception("You need to provide an API key.")
+
+
+def get_data(path: str) -> Any:
+    if _address is not None:
+        address = _address + "/api/v1/" + path
+        r = requests.get(address, headers=__headers())
+        if r.status_code == 200 or r.status_code == 201:
+            try:
+                return json.loads(r.text)
+            except Exception as e:
+                # We need better error handling here
+                raise Exception("JSON could not be parsed: " + str(e) +
+                                "\nJSON was\n" + r.text)
+        else:
+            r.raise_for_status()
+    else:
+        raise Exception("You have to authenticate first.")
+
+
+def post_data(path: str, data):
+    if _address is not None:
+        address = _address + "/api/v1/" + path
+        data = json.dumps(data)
+        requests.post(address, headers=__headers(),
+                      data=data).raise_for_status()
+    else:
+        raise Exception("You have to authenticate first.")
+
+
+def put_data(path: str, data):
+    if _address is not None:
+        address = _address + "/api/v1/" + path
+        data = json.dumps(data)
+        requests.put(address, headers=__headers(),
+                     data=data).raise_for_status()
+    else:
+        raise Exception("You have to authenticate first.")

--- a/sampledbapi/instruments.py
+++ b/sampledbapi/instruments.py
@@ -7,7 +7,8 @@ from typing import Dict, List, Optional, Any
 
 from requests import Response
 
-from sampledbapi import SampleDBObject, get_data, post_data, users
+from .comm import SampleDBObject, get_data, post_data
+from . import users
 
 __all__ = ["Instrument", "InstrumentLogCategory", "InstrumentLogEntry",
            "InstrumentLogFileAttachment", "InstrumentLogObjectAttachment",

--- a/sampledbapi/locations.py
+++ b/sampledbapi/locations.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from sampledbapi import SampleDBObject, get_data
+from .comm import SampleDBObject, get_data
 
 __all__ = ["Location", "get_list", "get"]
 

--- a/sampledbapi/locationtypes.py
+++ b/sampledbapi/locationtypes.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from sampledbapi import SampleDBObject, get_data
+from .comm import SampleDBObject, get_data
 
 __all__ = ["LocationType", "get_list", "get"]
 

--- a/sampledbapi/objects.py
+++ b/sampledbapi/objects.py
@@ -7,8 +7,8 @@ from typing import BinaryIO, Dict, List, Optional, Any
 
 from requests import Response
 
-from sampledbapi import SampleDBObject, get_data, locations, users, post_data, put_data
-from sampledbapi.users import User
+from . import locations, users
+from .comm import SampleDBObject, get_data, post_data, put_data
 
 __all__ = ["Object", "File", "Comment", "get_list", "get", "create"]
 
@@ -480,8 +480,8 @@ class LocationOccurence(SampleDBObject):
 
     object_id: Optional[int] = None
     location: Optional[locations.Location] = None
-    responsible_user: Optional[User] = None
-    user: Optional[User] = None
+    responsible_user: Optional[users.User] = None
+    user: Optional[users.User] = None
     description: Optional[str] = None
     utc_datetime: Optional[datetime] = None
 

--- a/sampledbapi/users.py
+++ b/sampledbapi/users.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from sampledbapi import SampleDBObject, get_data
+from .comm import SampleDBObject, get_data
 
 __all__ = ["User", "get_list", "get", "get_current"]
 

--- a/sampledbapi/utils.py
+++ b/sampledbapi/utils.py
@@ -1,7 +1,8 @@
 from datetime import datetime
-from sampledbapi import objects, SampleDBObject
 from typing import Optional, Dict
 
+from .comm import SampleDBObject
+from . import objects
 
 class TimeSeries(SampleDBObject):
     data: Optional[float] = None

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -70,7 +70,7 @@ class TestUtils():
         assert json2text('') is None
         assert json2text({'_type': 'test'}) is None
         
-    def test_json2quantity2json(self):
+    def test_json2text2json(self):
         json = {'_type': 'text', 'text': 'Test'}
         text = json2text(json)
         json2 = text2json(text)


### PR DESCRIPTION
I would like to use the wrapper as follows:

```python
import sampledbapi as sapi

api_token = '....'
address = '....'

sapi.authenticate(address, api_token)

print(sapi.actions.get_list())
print(sapi.objects.get(123))
```

So compared to the documented way in the README.md I would like to not use the `*` import to not mix up namespaces, as there might be different things called `objects` and `actions` in a program.

From README.md:
```python
from sampledbapi import *

server_address = ...
api_key = ...

# Authentication
authenticate(server_address, api_key)

# Simple queries
print(actions.get_list())
print(objects.get(123))
```

Therefore I would suggest to make the submodules available like I did in my Pull Requests, by importing them in the `__init__.py` file.
To limit the `__init__.py` to the module-import-handling-stuff I would suggest to move other functionality (authentication, communication) to a new file (`comm.py`).

This change does not break the documented way of using the sampledb-api-wrapper.

As there is no `develop` branch in this repo I targeted the `master` branch.