### PR TITLE
Minor suggested improvements

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -63,7 +63,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/doc/sampledbapi.comm.rst
+++ b/doc/sampledbapi.comm.rst
@@ -1,0 +1,8 @@
+sampledbapi.comm module
+=======================
+
+.. automodule:: sampledbapi.comm
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :private-members:

--- a/doc/sampledbapi.locationtypes.rst
+++ b/doc/sampledbapi.locationtypes.rst
@@ -1,0 +1,8 @@
+sampledbapi.locationtypes module
+================================
+
+.. automodule:: sampledbapi.locationtypes
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :private-members:

--- a/doc/sampledbapi.rst
+++ b/doc/sampledbapi.rst
@@ -15,7 +15,10 @@ Submodules
 
    sampledbapi.actions
    sampledbapi.actiontypes
+   sampledbapi.comm
    sampledbapi.instruments
    sampledbapi.locations
+   sampledbapi.locationtypes
    sampledbapi.objects
    sampledbapi.users
+   sampledbapi.utils

--- a/doc/sampledbapi.utils.rst
+++ b/doc/sampledbapi.utils.rst
@@ -1,0 +1,8 @@
+sampledbapi.utils module
+========================
+
+.. automodule:: sampledbapi.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :private-members:

--- a/sampledbapi/objects.py
+++ b/sampledbapi/objects.py
@@ -420,7 +420,7 @@ def get_list(q: str = "", action_id: int = -1, action_type: str = "",
     information.
 
     Args:
-        q (str): Search string for advanced search, `see here. <https://scientific-it-systems.iffgit.fz-juelich.de/SampleDB/user_guide/objects.html#advanced-search>`__
+        q (str): Search string for advanced search, `see here. <https://scientific-it-systems.iffgit.fz-juelich.de/SampleDB/user_guide/search.html#advanced-search>`__
         action_id (int): Filter by action ID.
         action_type (str): Filter by action type.
         limit (int): Limit number of results (helpful for pagination).


### PR DESCRIPTION
**[Return server response text on 4xx errors](https://github.com/AG-Salinga/sampledb-api-wrapper/commit/90c11a58280a7200b554b1c598497f36d70b9a58)**
As it is useful to me to get the SampleDB API's answer in case of an error (e.g. when sending invalid data) to identify the mistake made I would suggest to include the SampleDB answer for that kind of errors/HTTP status codes.
**Example:**
```
Exception: 400 Client Error: BAD REQUEST for url: https://example.com/api/v1/objects/
Response text: {"message":"validation failed:\n - conditions for property \"operator\" not fulfilled (at operator_or_text -> operator)\n - value must be bool (at operator_or_text -> operator_is_user)","error_paths":[["operator_or_text","operator"],["operator_or_text","operator_is_user"]]}
```
instead of previous message:
```
requests.exceptions.HTTPError: 400 Client Error: BAD REQUEST for url: https://example.com/api/v1/objects/
```

**[Update link to SampleDB documentation as the search section moved](https://github.com/AG-Salinga/sampledb-api-wrapper/commit/414aa4d40b1765879ea610700180891068303133)**
https://scientific-it-systems.iffgit.fz-juelich.de/SampleDB/user_guide/objects.html#advanced-search ➡️ https://scientific-it-systems.iffgit.fz-juelich.de/SampleDB/user_guide/search.html#advanced-search

**[Include missing submodules in documentation](https://github.com/AG-Salinga/sampledb-api-wrapper/commit/60c831c110434c1532cd372585fc3e1d9dafa062)**
Some of the submodules were missing in the documentation.
Also I added the automatically created `rst` files for consistency, as the other files created by `sphinx-apidoc` where included as well. It might be even "cleaner" to remove all auto-generated documentation content from the repository.