### PR TITLE
Fix instrument log entry versions, add new properties

### DIFF
--- a/sampledbapi/instruments.py
+++ b/sampledbapi/instruments.py
@@ -167,31 +167,50 @@ class InstrumentLogCategory(SampleDBObject):
         return f"InstrumentLogCategory {self.category_id} ({self.title})"
 
 
+class InstrumentLogEntryVersion(SampleDBObject):
+
+    log_entry_id: Optional[int] = None
+    version_id: Optional[int] = None
+    utc_datetime: Optional[datetime] = None
+    content: Optional[str] = None
+    categories: Optional[List[InstrumentLogCategory]] = None
+    event_utc_datetime: Optional[datetime] = None
+    content_is_markdown: Optional[bool] = None
+
+    def __init__(self, d: Dict):
+        """Initialize a new instrument log entry version from dictionary."""
+        super().__init__(d)
+
+        if "categories" in d:
+            self.categories = [InstrumentLogCategory(c) for c in d["categories"]]
+        if "utc_datetime" in d:
+            self.utc_datetime = datetime.strptime(d["utc_datetime"], '%Y-%m-%dT%H:%M:%S.%f')
+        if "event_utc_datetime" in d and d["event_utc_datetime"] is not None:
+            self.event_utc_datetime = datetime.strptime(d["event_utc_datetime"], '%Y-%m-%dT%H:%M:%S.%f')
+
+    def __repr__(self) -> str:
+        return f"InstrumentLogEntry {self.log_entry_id} (created {self.utc_datetime})"
+
+
 class InstrumentLogEntry(SampleDBObject):
 
     log_entry_id: Optional[int] = None
     instrument_id: Optional[int] = None
-    utc_datetime: Optional[datetime] = None
     author: Optional[users.User] = None
-    content: Optional[str] = None
-    categories: Optional[List[InstrumentLogCategory]] = None
+    versions: Optional[List[InstrumentLogEntryVersion]] = None
 
     def __init__(self, instrument_id: int, d: Dict):
         """Initialize a new instrument log entry from dictionary."""
         super().__init__(d)
         self.instrument_id = instrument_id
-        if "categories" in d:
-            self.categories = [
-                InstrumentLogCategory(c) for c in d["categories"]]
+
         if "author" in d:
             self.author = users.get(d["author"])
-        if "utc_datetime" in d:
-            self.utc_datetime = datetime.strptime(
-                d["utc_datetime"], '%Y-%m-%dT%H:%M:%S.%f')
+        if "versions" in d:
+            self.versions = [InstrumentLogEntryVersion(v) for v in d["versions"]]
 
     def __repr__(self) -> str:
-        return f"InstrumentLogEntry {self.log_entry_id} " \
-            + f"(created {self.utc_datetime})"
+        return f"InstrumentLogEntry {self.log_entry_id}"
 
     def get_file_attachment_list(self) -> List[InstrumentLogFileAttachment]:
         """Get a list of file attachments.


### PR DESCRIPTION
1. Fixes instrument log entry retrieval: instrument log entries are versioned, which was not correctly documented in the SampleDB API documentation (fixed in [7d657aad](https://github.com/sciapp/sampledb/commit/7d657aad0b3b422d70a86cd0ca3e2eb4c75dec6d))
2. Adds the properties `event_utc_datetime` and `content_is_markdown` to the instrument log entry versions, as introduced in [bcfc9da](https://github.com/sciapp/sampledb/commit/bcfc9dabaa4588ccc9591694b60261ed73efa95e). Values are `None` for older SampleDB versions