### PR TITLE
Add role and email properties to User

### DIFF
--- a/sampledbapi/users.py
+++ b/sampledbapi/users.py
@@ -11,6 +11,8 @@ class User(SampleDBObject):
     name: Optional[str] = None
     orcid: Optional[str] = None
     affiliation: Optional[str] = None
+    role: Optional[str] = None
+    email: Optional[str] = None
 
     def __repr__(self) -> str:
         return f"User {self.user_id} ({self.name})"


### PR DESCRIPTION
This PR adds `User.role` and `User.email`, which as usual fall back to `None` if not defined, e.g. in the case of `email` if the API-user is no administrator.