### PR TITLE
Only deploy and mirror in ag-salinga's repository

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,6 +54,8 @@ mirror:
     - chmod 400 ~/.ssh/*
     - git clone --mirror "$CI_REPOSITORY_URL" repo
     - cd repo && git push --mirror git@github.com:AG-Salinga/sampledb-api-wrapper && cd -
+  only:
+    - branches@ag-salinga/sampledb-api-wrapper
 
 deploy_production:
   stage: deploy
@@ -72,7 +74,7 @@ deploy_production:
       - dist/
     expire_in: 6 months
   only:
-    - tags
+    - tags@ag-salinga/sampledb-api-wrapper
 
 pages:
   stage: deploy
@@ -89,7 +91,7 @@ pages:
     - cd ..
     - mv .public public
   only:
-    - tags
+    - tags@ag-salinga/sampledb-api-wrapper
   artifacts:
     paths:
       - public


### PR DESCRIPTION
As the mirror task fails in our Gitlab (as it is not configured because it can and should not mirror to the ag-salinga github repository) I suggest to set up mirror and deplay jobs to be only executed in the ag-salinga repository.
To be more precise: Only in a repository named sampledb-api-wrapper of a group named ag-salinga. The server is not included in this configuration.