### PR TITLE
Use requests params to correctly encode object requests

### DIFF
--- a/sampledbapi/objects.py
+++ b/sampledbapi/objects.py
@@ -433,7 +433,6 @@ def get_list(q: str = "", action_id: int = -1, action_type: str = "",
     if (isinstance(q, str) and isinstance(action_id, int) and
             isinstance(action_type, str) and isinstance(limit, int) and
             isinstance(offset, int) and isinstance(name_only, bool)):
-        s = "objects"
         pars: Dict[str, Any] = {}
         if q != "":
             pars["q"] = q
@@ -448,14 +447,7 @@ def get_list(q: str = "", action_id: int = -1, action_type: str = "",
         if name_only:
             pars["name_only"] = "true"
 
-        if len(pars) > 0:
-            s += "?"
-        for i, p in enumerate(pars):
-            s += f"{p}={pars[p]}"
-            if i < len(pars) - 1:
-                s += "&"
-
-        return [Object(o) for o in get_data(s)]
+        return [Object(o) for o in get_data("objects", pars)]
     else:
         raise TypeError()
 


### PR DESCRIPTION
The manual handling of the URL including GET parameters did not encode it.
This required to encode a query string manually before passing it to `objects.get_list()`, e.g. `q='"Die_43"+in+measurements.%3F.sample.wafer'` instead of `q='"Die_43" in measurements.?.sample.wafer'`.

In this PR I suggest to let the `requests` library handle this, as I introduced for object log requests in PR #5 using the `params` argument.